### PR TITLE
Assign arch specific value to MAVEN_IMAGE for maven and jib-maven tasks

### DIFF
--- a/demo
+++ b/demo
@@ -105,6 +105,15 @@ demo.test() {
     local clustertasks=$@
   fi
 
+  OSArch=$(uname -m)
+  if [ "$OSArch" == "ppc64le" ]; then
+          sed -i 's/gcr.io\/cloud-builders\/mvn@sha256:57523fc43394d6d9d2414ee8d1c85ed7a13460cbb268c3cd16d28cfb3859e641/maven:3.6.3-adoptopenjdk-8/' ./maven/pipeline.yaml
+          sed -i 's/gcr.io\/cloud-builders\/mvn@sha256:57523fc43394d6d9d2414ee8d1c85ed7a13460cbb268c3cd16d28cfb3859e641/maven:3.6.3-adoptopenjdk-8/' ./jib-maven/pipeline.yaml
+  elif [ "$OSArch" == "s390x" ]; then
+          sed -i 's/gcr.io\/cloud-builders\/mvn@sha256:57523fc43394d6d9d2414ee8d1c85ed7a13460cbb268c3cd16d28cfb3859e641/maven:3.6.3-adoptopenjdk-11/' ./maven/pipeline.yaml
+          sed -i 's/gcr.io\/cloud-builders\/mvn@sha256:57523fc43394d6d9d2414ee8d1c85ed7a13460cbb268c3cd16d28cfb3859e641/maven:3.6.3-adoptopenjdk-11/' ./jib-maven/pipeline.yaml
+  fi
+
   for clustertask in $clustertasks; do
     # remove trailing slash and subdirs (a -> a, b/ -> b, c/d/e -> c)
     local testname=${clustertask%%/*}

--- a/jib-maven/pipeline.yaml
+++ b/jib-maven/pipeline.yaml
@@ -36,6 +36,8 @@ spec:
     params:
     - name: DIRECTORY
       value: $(params.SUBDIR)
+    - name: MAVEN_IMAGE
+      value: gcr.io/cloud-builders/mvn@sha256:57523fc43394d6d9d2414ee8d1c85ed7a13460cbb268c3cd16d28cfb3859e641
     - name: IMAGE
       value: image-registry.openshift-image-registry.svc:5000/catalog-tests/console-java-simple
     - name: INSECUREREGISTRY

--- a/maven/pipeline.yaml
+++ b/maven/pipeline.yaml
@@ -30,3 +30,6 @@ spec:
       workspace: source
     - name: maven-settings
       workspace: maven-settings
+      params:
+    - name: MAVEN_IMAGE
+      value: gcr.io/cloud-builders/mvn@sha256:57523fc43394d6d9d2414ee8d1c85ed7a13460cbb268c3cd16d28cfb3859e641

--- a/maven/pipeline.yaml
+++ b/maven/pipeline.yaml
@@ -30,6 +30,6 @@ spec:
       workspace: source
     - name: maven-settings
       workspace: maven-settings
-      params:
+    params:
     - name: MAVEN_IMAGE
       value: gcr.io/cloud-builders/mvn@sha256:57523fc43394d6d9d2414ee8d1c85ed7a13460cbb268c3cd16d28cfb3859e641


### PR DESCRIPTION
Hi ,

PR raised for required fix for addition of MAVEN_IMAGE parameter to jib-maven and maven tasks for P and Z(different values)  than x86. 

I have allocated default value as below for x86 and replaced it in case arch is P and Z.  Please review and let me know if any changes are required. 
 
/maven/pipeline.yaml 
/jib-maven/pipeline.yaml 
 name: MAVEN_IMAGE
     value: gcr.io/cloud-builders/mvn@sha256:57523fc43394d6d9d2414ee8d1c85ed7a13460cbb268c3cd16d28cfb3859e641

Thanks,
Snehlata Mohite. 