### PR TITLE
Power platform will also use maven:3.6.3-adoptopenjdk-11

### DIFF
--- a/demo
+++ b/demo
@@ -57,9 +57,7 @@ show_failures() {
 
 set_maven_image() {
   os_arch=$(uname -m)
-  if [ "$os_arch" == "ppc64le" ]; then
-    sed -i "s|IMAGE_CHANGEME|maven:3.6.3-adoptopenjdk-8|" $1/pipeline.yaml
-  elif [ "$os_arch" == "s390x" ]; then
+  if [ "$os_arch" == "ppc64le" ] || [ "$os_arch" == "s390x" ]; then
     sed -i "s|IMAGE_CHANGEME|maven:3.6.3-adoptopenjdk-11|" $1/pipeline.yaml
   else
     image=$(oc get clustertask $1 -o jsonpath="{.spec.params[?(@.name == 'MAVEN_IMAGE')].default}")


### PR DESCRIPTION
Hi All,

Please review changes. For Power also maven:3.6.3-adoptopenjdk-11 instead of maven:3.6.3-adoptopenjdk-8. 

Tested maven cluster task works fine on Power with maven:3.6.3-adoptopenjdk-11. 

[ cluster-tasks-tests]# oc get pr -A
NAMESPACE       NAME              SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
catalog-tests   maven-run-zhksr   True        Succeeded   41s         7s


Thanks,
Snehlata Mohite. 